### PR TITLE
Make same nesting levels have the same color

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write # for release-drafter/release-drafter to create a github release
+      pull-requests: write # for release-drafter/release-drafter to add label to PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/main/scala/io/github/jisantuc/rbparencli/Main.scala
+++ b/src/main/scala/io/github/jisantuc/rbparencli/Main.scala
@@ -16,22 +16,22 @@ object Main
       "0.0.1"
     ) {
 
-  var colorStack = List.empty[Color]
+  private var openCount: Int = 0
 
   private def colorize(palette: Palette)(c: Char): String = {
     val openChars = Set('[', '(', '{')
     val closeChars = Set(']', ')', '}')
     c match {
       case ch if openChars.contains(ch) =>
+        openCount += 1
         val nextColor = palette.colors.next
-        colorStack = colorStack :+ nextColor
         nextColor.colorText(s"$ch")
       case ch if closeChars.contains(ch) =>
-        if (colorStack.isEmpty) {
+        if (openCount == 0) {
           palette.error.colorText(s"$ch")
         } else {
-          val nextColor = colorStack.last
-          colorStack = colorStack.dropRight(1)
+          openCount -= 1
+          val nextColor = palette.colors.previous
           nextColor.colorText(s"$ch")
         }
       case c => s"$c"

--- a/src/main/scala/io/github/jisantuc/rbparencli/Ring.scala
+++ b/src/main/scala/io/github/jisantuc/rbparencli/Ring.scala
@@ -8,6 +8,8 @@ trait Ring[A] {
   protected[rbparencli] val underlying: List[A]
 
   def next: A
+
+  def previous: A
 }
 
 object Ring {
@@ -25,6 +27,11 @@ object Ring {
       val out = underlying(idx)
       cursor += 1
       out
+    }
+
+    def previous = {
+      cursor -= 1
+      underlying(idx)
     }
   }
 


### PR DESCRIPTION
This PR makes it so that in a document like:

```
[
  { someObject1 },
  { someObject2 }
]
```

the braces around `someObject1` and `someObject2` will have the same color. I did some reading about other rainbow bracket extensions and consistent coloring for an indentation level seems to be pretty common.

It also adds the release drafter action which won't work until it's merged to `main` but I think i have set up right. 🤞🏻 we'll see